### PR TITLE
Add option to sort json by keys

### DIFF
--- a/extension/pages/options.html
+++ b/extension/pages/options.html
@@ -42,6 +42,9 @@
               <li>
                 <strong>"alwaysRenderAllContent"</strong> - <span class="hint">Disables the custom search and renders all content. Be aware that with this option <span class="underline">large files</span> will have a <span class="underline">significant performance reduction</span> (boolean)</span>
               </li>
+              <li>
+                <strong>"sortKeys"</strong> - <span class="hint">Sort objects by key (boolean)</span>
+              </li>
             </ul>
           </div>
         </header>

--- a/extension/src/json-viewer/content-extractor.js
+++ b/extension/src/json-viewer/content-extractor.js
@@ -16,7 +16,7 @@ var REPLACE_WRAP_REGEX = new RegExp(
 );
 
 var sortByKeys = function(obj) {
-    if (!(typeof obj === 'function' || typeof obj === 'object' && !!obj)) {
+    if (typeof obj !== 'object' || !obj) {
         return obj;
     }
     var sorted;

--- a/extension/src/json-viewer/highlight-content.js
+++ b/extension/src/json-viewer/highlight-content.js
@@ -25,7 +25,7 @@ function highlightContent(pre, outsideViewer) {
     if (oversizedJSON(pre, options)) return pre.hidden = false;
 
     return loadRequiredCss(options).
-      then(function() { return contentExtractor(pre) }).
+      then(function() { return contentExtractor(pre, options) }).
       then(function(value) {
 
         var formatted = prependHeader(options, outsideViewer, value.jsonText);


### PR DESCRIPTION
Add option to sort json by keys.

This uses a v8 quirk that causes objects to be iterated by insert order. I would have preferred to not have used this quirk but I think I would have had to make a lot more changes or write my own JSON.stringify.