### PR TITLE
Bug fix: quotes incorrectly parsed by wrapNumbers resulting in broken json

### DIFF
--- a/extension/src/json-viewer/content-extractor.js
+++ b/extension/src/json-viewer/content-extractor.js
@@ -71,6 +71,7 @@ function wrapNumbers(text) {
   var buffer = "";
   var numberBuffer = "";
   var isInString = false;
+  var charIsEscaped = false;
   var isInNumber = false;
   var previous = "";
   var beforePrevious = "";
@@ -78,7 +79,7 @@ function wrapNumbers(text) {
   for (var i = 0, len = text.length; i < len; i++) {
     var char = text[i];
 
-    if (char == '"' && (previous != '\\' || (previous == '\\' && beforePrevious == '\\'))) {
+    if (char == '"' && !charIsEscaped) {
       isInString = !isInString;
     }
 
@@ -98,6 +99,9 @@ function wrapNumbers(text) {
 
       numberBuffer = "";
     }
+
+    // this applies to the _next_ character - the one used in the next iteration
+    charIsEscaped = (char == '\\') ? !charIsEscaped : false
 
     if (isInNumber) {
       numberBuffer += char;

--- a/tests/test.backslash.json
+++ b/tests/test.backslash.json
@@ -1,4 +1,5 @@
 {
+  "triple-backslash": "\\\"99\\\"",
   "path": "C:\\foobar\\",
   "number": 123,
   "foo": "bar"


### PR DESCRIPTION
A bug occurs when there are an odd number of backslashes, followed by a quote, followed by a number, resulting in wrapNumbers believing it's no longer inside a string when in fact it is.