### PR TITLE
Option to force utf8 encoding

### DIFF
--- a/extension/src/json-viewer/options/defaults.js
+++ b/extension/src/json-viewer/options/defaults.js
@@ -8,7 +8,8 @@ module.exports = {
     sortKeys: false,
     clickableUrls: true,
     openLinksInNewWindow: true,
-    autoHighlight: true
+    autoHighlight: true,
+    forceUTF8: false,
   },
   structure: {
     readOnly: true,


### PR DESCRIPTION
Fixes #146 

Because the conversion from the http/browser default encoding (windows 1252) to utf8 is lossy, the only way I can see to force UTF8 encoding is to re-request the resource and overriding the mimetype.

- If the interest arises can add support for other encodings, but sticking to utf8 for now.
- On another branch I have a rough implementation of being able to toggle between the encodings (similar to the 'raw' button) however I don't know how useful this would actually be.