### PR TITLE
Added option to show url as anchor tag

### DIFF
--- a/extension/pages/options.html
+++ b/extension/pages/options.html
@@ -49,6 +49,9 @@
                 <strong>"clickableUrls"</strong> - <span class="hint">Make URLs clickable (boolean). Default true</span>
               </li>
               <li>
+                <strong>"wrapLinkWithAnchorTag"</strong> - <span class="hint">Add URLs as anchor tag (boolean). Default false</span>
+              </li>
+              <li>
                 <strong>"openLinksInNewWindow"</strong> - <span class="hint">Open URLs in the same window/tab (boolean). Default true</span>
               </li>
               <li>

--- a/extension/src/json-viewer/highlighter.js
+++ b/extension/src/json-viewer/highlighter.js
@@ -91,6 +91,14 @@ Highlighter.prototype = {
         elements.forEach(function(node) {
           node.classList.add("cm-string-link");
           node.setAttribute("data-url", decodedText);
+          if (self.wrapLinkWithAnchorTag()) {
+            var linkTag = document.createElement("a");
+            linkTag.href = decodedText;
+            linkTag.setAttribute('target', '_blank')
+            linkTag.innerHTML = decodedText;
+            node.innerHTML = "";
+            node.appendChild(linkTag);
+          }
         });
       }
     });
@@ -198,6 +206,10 @@ Highlighter.prototype = {
 
   clickableUrls: function() {
     return this.options.addons.clickableUrls;
+  },
+
+  wrapLinkWithAnchorTag: function() {
+    return this.options.addons.wrapLinkWithAnchorTag;
   },
 
   openLinksInNewWindow: function() {

--- a/extension/src/json-viewer/options/defaults.js
+++ b/extension/src/json-viewer/options/defaults.js
@@ -7,6 +7,7 @@ module.exports = {
     alwaysRenderAllContent: false,
     sortKeys: false,
     clickableUrls: true,
+    wrapLinkWithAnchorTag: false,
     openLinksInNewWindow: true,
     autoHighlight: true
   },


### PR DESCRIPTION
Added option to wrap url as anchor tag. This was super useful while using chrome extension [imagus](https://chrome.google.com/webstore/detail/imagus/immpkjjlgappgfkkfieppnmlhakdmaab?hl=en). Thought this will be useful for other, and also once its merged to master, I can start using json-viewer from chrome store again.