### PR TITLE
Preserve spaces in plain strings

### DIFF
--- a/extension/src/json-viewer/jsl-format.js
+++ b/extension/src/json-viewer/jsl-format.js
@@ -73,7 +73,10 @@ jsl.format = (function () {
                 }
                 break;
             case '"':
-                if (i > 0 && (json.charAt(i - 1) !== '\\' || (json.charAt(i - 1) == '\\' && json.charAt(i - 2) == '\\'))) {
+                if (i === 0) {
+                    inString = true;
+                }
+                else if (json.charAt(i - 1) !== '\\' || (json.charAt(i - 1) == '\\' && json.charAt(i - 2) == '\\')) {
                     inString = !inString;
                 }
                 newJson += currentChar;


### PR DESCRIPTION
Fixes #152.

Treat double-quote characters at the beginning of the received JSON as
the beginning of a string.

Previously, a double-quote character at position 0 of the received JSON
was disregarded (causing any spaces in the JSON string to be removed).