### PR TITLE
showArraySize now defaults to true

### DIFF
--- a/extension/pages/options.html
+++ b/extension/pages/options.html
@@ -76,7 +76,7 @@
                 <strong>"indentCStyle"</strong> - <span class="hint">Default false</span>
               </li>
               <li>
-                <strong>"showArraySize"</strong> - <span class="hint">Default false</span>
+                <strong>"showArraySize"</strong> - <span class="hint">Default true</span>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
https://github.com/tulios/json-viewer/pull/122 changes the default from false to true.