### PR TITLE
showArraySize should default to false if undefined.

### DIFF
--- a/extension/src/json-viewer/jsl-format.js
+++ b/extension/src/json-viewer/jsl-format.js
@@ -44,7 +44,7 @@ jsl.format = (function () {
         options = options || {};
         var tabSize = options.tabSize || 2;
         var indentCStyle = options.indentCStyle || false;
-        var showArraySize = (typeof options.showArraySize !== "undefined" ? Boolean(options.showArraySize) : true);
+        var showArraySize = (typeof options.showArraySize !== "undefined" ? Boolean(options.showArraySize) : false);
         var tab = "";
         for (var ts = 0; ts < tabSize; ts++) {
           tab += " ";


### PR DESCRIPTION
I'm submitting this PR because I think the extension behavior changed for me and I see `showArraySize` default changed from `true` to `false` about a week ago.

I don't fully understand this code base. I don't see why the `true/false` is hardcoded in the modified line. I would expect that to refer to `structure` in `extension/src/json-viewer/options/defaults.js`.