### PR TITLE
Set window.json when formatting from scratch page

### DIFF
--- a/extension/src/json-viewer/check-if-json.js
+++ b/extension/src/json-viewer/check-if-json.js
@@ -72,4 +72,7 @@ function checkIfJson(sucessCallback, element) {
   }
 }
 
-module.exports = checkIfJson;
+module.exports = {
+  checkIfJson: checkIfJson,
+  isJSON: isJSON
+};

--- a/extension/src/json-viewer/scratch-pad/load-editor.js
+++ b/extension/src/json-viewer/scratch-pad/load-editor.js
@@ -5,6 +5,8 @@ var loadRequiredCss = require('../viewer/load-required-css');
 var renderExtras = require('../viewer/render-extras');
 var renderFormatButton = require('./render-format-button');
 var jsonFormater = require('../jsl-format');
+var JSONUtils = require('../check-if-json');
+var exposeJson = require('../viewer/expose-json');
 
 function loadEditor(pre) {
   getOptions().then(function(options) {
@@ -19,6 +21,9 @@ function loadEditor(pre) {
       renderFormatButton(function() {
         var text = highlighter.editor.getValue();
         highlighter.editor.setValue(jsonFormater(text));
+        if (JSONUtils.isJSON(text)) {
+          exposeJson(text, true);
+        }
       });
 
     });

--- a/extension/src/omnibox-page.js
+++ b/extension/src/omnibox-page.js
@@ -1,4 +1,4 @@
-var checkIfJson = require('./json-viewer/check-if-json');
+var JSONUtils = require('./json-viewer/check-if-json');
 var highlightContent = require('./json-viewer/highlight-content');
 var loadScratchPadEditor = require('./json-viewer/scratch-pad/load-editor');
 
@@ -19,7 +19,7 @@ function handleJSONHighlight(pre, query) {
   var rawJson = query.replace(/^json=/, '');
   pre.innerText = decodeURIComponent(rawJson);
 
-  checkIfJson(function(pre) {
+  JSONUtils.checkIfJson(function(pre) {
     pre.hidden = true;
     highlightContent(pre, true);
   }, pre);

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1,9 +1,9 @@
 require('./viewer-styles');
-var checkIfJson = require('./json-viewer/check-if-json');
+var JSONUtils = require('./json-viewer/check-if-json');
 var highlightContent = require('./json-viewer/highlight-content');
 
 function onLoad() {
-  checkIfJson(function(pre) {
+  JSONUtils.checkIfJson(function(pre) {
     pre.hidden = true;
     highlightContent(pre);
   });


### PR DESCRIPTION
This PR sets the global `json` variable if the text pasted onto the scratch page is valid json. Mentioned in #56, this feature is triggered by the format button 