### PR TITLE
Ignore header while setting line numbers

### DIFF
--- a/extension/src/json-viewer/highlight-content.js
+++ b/extension/src/json-viewer/highlight-content.js
@@ -54,6 +54,7 @@ function oversizedJSON(pre, options, outsideViewer) {
 
 function prependHeader(options, outsideViewer, jsonText) {
   if (!outsideViewer && options.addons.prependHeader) {
+    options.structure.firstLineNumber = options.structure.firstLineNumber - 3
     var header = "// " + timestamp() + "\n";
     header += "// " + document.location.href + "\n\n";
     jsonText = header + jsonText;

--- a/extension/src/json-viewer/options/defaults.js
+++ b/extension/src/json-viewer/options/defaults.js
@@ -14,6 +14,7 @@ module.exports = {
   structure: {
     readOnly: true,
     lineNumbers: true,
+    firstLineNumber: 1,
     lineWrapping: true,
     foldGutter: true,
     tabSize: 2,


### PR DESCRIPTION
Use the `firstLineNumber` property to ignore headers while setting line
numbers.

Fixes #198 