### PR TITLE
Fix openLinksInNewWindow

### DIFF
--- a/extension/src/json-viewer/highlighter.js
+++ b/extension/src/json-viewer/highlighter.js
@@ -92,7 +92,7 @@ Highlighter.prototype = {
           if (self.wrapLinkWithAnchorTag()) {
             var linkTag = document.createElement("a");
             linkTag.href = decodedText;
-            linkTag.setAttribute('target', '_blank')
+            linkTag.setAttribute('target', self.getLinkTarget());
             linkTag.classList.add("cm-string");
 
             // reparent the child nodes to preserve the cursor when editing
@@ -122,11 +122,7 @@ Highlighter.prototype = {
       var element = event.target;
       if (element.classList.contains("cm-string-link")) {
         var url = element.getAttribute("data-url")
-        var target = "_self";
-        if (self.openLinksInNewWindow()) {
-          target = "_blank";
-        }
-        window.open(url, target);
+        window.open(url, self.getLinkTarget());
       }
     });
   },
@@ -225,6 +221,10 @@ Highlighter.prototype = {
 
   openLinksInNewWindow: function() {
     return this.options.addons.openLinksInNewWindow;
+  },
+
+  getLinkTarget: function() {
+    return this.openLinksInNewWindow() ? "_blank" : "_self";
   },
 
   isReadOny: function() {


### PR DESCRIPTION
Currently, if you set the `wrapLinkWithAnchorTag` option to `true` then
the value of `openLinksInNewWindow` is ignored and links are always
opened in a new window.  This change modifies the code to take the
`openLinksInNewWindow` option into account for determining the link
target.