### PR TITLE
Fix back keyboard shortcut

### DIFF
--- a/extension/src/json-viewer/highlighter.js
+++ b/extension/src/json-viewer/highlighter.js
@@ -191,6 +191,11 @@ Highlighter.prototype = {
     var nativeSearch = this.alwaysRenderAllContent();
     extraKeyMap["Ctrl-F"] = nativeSearch ? false : this.openSearchDialog;
     extraKeyMap["Cmd-F"] = nativeSearch ? false : this.openSearchDialog;
+
+    delete CodeMirror.keyMap.macDefault["Cmd-["];
+    delete CodeMirror.keyMap.pcDefault["Alt-Left"];
+    extraKeyMap["Cmd-Left"] = function() { window.history.back(); };
+
     return extraKeyMap;
   },
 


### PR DESCRIPTION
This pull request disables some of the key command functionality of CodeMirror, enabling Chrome browser keyboard shortcuts to navigate back. Fixes https://github.com/tulios/json-viewer/issues/124.

For some reason, the `extraKeyMap` object had to be used to restore the "Cmd-Left" command.

https://github.com/tulios/json-viewer/issues/220 could also be fixed by adding "Page Up" and "Page Down" keys to `extraKeyMap` and scrolling the CodeMirror editor. For the space key to scroll down may require adding a "keydown" listener though.