### PR TITLE
Fix empty strings being treated as URLs

### DIFF
--- a/extension/src/json-viewer/highlighter.js
+++ b/extension/src/json-viewer/highlighter.js
@@ -86,7 +86,7 @@ Highlighter.prototype = {
 
       var text = self.removeQuotes(textContent);
 
-      if (text.match(URL_PATTERN) && self.clickableUrls()) {
+      if (text && text.match(URL_PATTERN) && self.clickableUrls()) {
         var decodedText = self.decodeText(text);
         elements.forEach(function(node) {
           if (self.wrapLinkWithAnchorTag()) {


### PR DESCRIPTION
Adds a check to see if text is empty before making it a link.

Fixes #279.