### PR TITLE
Update url-pattern.js to include 'devtools' URL

### DIFF
--- a/extension/src/json-viewer/url-pattern.js
+++ b/extension/src/json-viewer/url-pattern.js
@@ -59,7 +59,7 @@ function relativePath() {
 }
 
 function absolutePath() {
-    return "(?:(?:https?|ftp)://)" +        /* protocol identifier*/
+    return "(?:(?:https?|ftp|devtools)://)" +        /* protocol identifier*/
         "(?:\\S+(?::\\S*)?@)?" +            /* user:pass authentication*/
         "(?:" +
         "(?:\\[[a-f0-9.:]+\\])" +           /* IPv6 or hybrid addresses*/


### PR DESCRIPTION
Thanks for `json-viewer`, it's been really nice to have. You wouldn't believe the time I've saved with it!

This PR would allow nodejs debugger links to be clickable when visiting `/json/list`. Thanks for considering it!

<img width="323" alt="image" src="https://github.com/tulios/json-viewer/assets/1312390/bf3b9e01-ee61-4eab-8953-4d8b9669e630">
